### PR TITLE
Another permission issue - key for adding a permission policy is wrong

### DIFF
--- a/provision_utils.go
+++ b/provision_utils.go
@@ -118,8 +118,8 @@ func ensureIAMRoleResource(awsPrincipalName string, sourceArn string, resources 
 			policies := properties.(ArbitraryJSONObject)["Policies"]
 			rootPolicy := policies.([]ArbitraryJSONObject)[0]
 			policyDocument := rootPolicy["PolicyDocument"].(ArbitraryJSONObject)
-			statements := policyDocument["Statements"].([]ArbitraryJSONObject)
-			policyDocument["Statements"] = append(statements, ArbitraryJSONObject{
+			statements := policyDocument["Statement"].([]ArbitraryJSONObject)
+			policyDocument["Statement"] = append(statements, ArbitraryJSONObject{
 				"Effect":   "Allow",
 				"Action":   principalActions,
 				"Resource": sourceArn,


### PR DESCRIPTION
I sent the pull request for checking for existing permissions but I didn't correct the key when adding one. It seems it should be 'Statement' and not 'Statements'.