### PR TITLE
BUGFIX: Fixes problem with Kinesis Event Source

### DIFF
--- a/sparta.go
+++ b/sparta.go
@@ -415,7 +415,10 @@ func (roleDefinition *IAMRoleDefinition) toResource(eventSourceMappings []*Event
 			case "dynamodb":
 				statements = append(statements, CommonIAMStatements.DynamoDB...)
 			case "kinesis":
-				statements = append(statements, CommonIAMStatements.Kinesis...)
+				for _, statement := range CommonIAMStatements.Kinesis {
+					statement.Resource = gocf.String(eachEventSourceMapping.EventSourceArn)
+					statements = append(statements, statement)
+				}
 			default:
 				logger.Debug("No additional statements found")
 			}


### PR DESCRIPTION
This change fixes a bug when using a Kinesis stream as an event source. As is, the CloudFormation template verification throws a 400 status with an error message of: 'null' values are not allowed in templates, which is resulting from the CommonIAMStatements.Kinesis value not containing the Event Source ARN.