### PR TITLE
Added the ability to override the function name

### DIFF
--- a/sparta.go
+++ b/sparta.go
@@ -256,8 +256,8 @@ type LambdaFunction func(*json.RawMessage, *LambdaContext, http.ResponseWriter, 
 // to "nodejs4.3" (at least until golang is officially supported). See
 // http://docs.aws.amazon.com/lambda/latest/dg/programming-model.html
 type LambdaFunctionOptions struct {
-	// Function Name
-	Name string
+	// Additional params
+	SpartaOptions
 	// Additional function description
 	Description string
 	// Memory limit
@@ -274,6 +274,12 @@ func defaultLambdaFunctionOptions() *LambdaFunctionOptions {
 		Timeout:    3,
 		VpcConfig:  nil,
 	}
+}
+
+// SpartaOptions allow the passing in of additional options during the creation of a Lambda Function
+type SpartaOptions struct {
+	// Function Name
+	Name string
 }
 
 // TemplateDecorator allows Lambda functions to annotate the CloudFormation

--- a/sparta.go
+++ b/sparta.go
@@ -256,6 +256,8 @@ type LambdaFunction func(*json.RawMessage, *LambdaContext, http.ResponseWriter, 
 // to "nodejs4.3" (at least until golang is officially supported). See
 // http://docs.aws.amazon.com/lambda/latest/dg/programming-model.html
 type LambdaFunctionOptions struct {
+	// Function Name
+	Name string
 	// Additional function description
 	Description string
 	// Memory limit
@@ -938,8 +940,12 @@ func NewLambda(roleNameOrIAMRoleDefinition interface{},
 		lambdaOptions = defaultLambdaFunctionOptions()
 	}
 	lambdaPtr := runtime.FuncForPC(reflect.ValueOf(fn).Pointer())
+	lambdaFuncName := lambdaPtr.Name()
+	if lambdaOptions.Name != "" {
+		lambdaFuncName = lambdaOptions.Name
+	}
 	lambda := &LambdaAWSInfo{
-		lambdaFnName:        lambdaPtr.Name(),
+		lambdaFnName:        lambdaFuncName,
 		lambdaFn:            fn,
 		Options:             lambdaOptions,
 		Permissions:         make([]LambdaPermissionExporter, 0),


### PR DESCRIPTION
This is useful in the following situation:

``` go
for c := range configs {
  handler := &Handler{c}
  cwEventFn := sparta.NewLambda(
    sparta.IAMRoleDefinition{}, 
    handler.LambdaHandler, 
    &sparta.LambdaFunctionOptions{
      Name: fmt.Sprintf("xxx-%s", c.Name),
    }
  )
}
```

(Currently, I'm blocked from doing this because the function name obtained through reflection is the same for each instance of `Handler`)
