### PR TITLE
Change marshalling to match APIGatewayLambdaJSONEvent

### DIFF
--- a/explore/explore.go
+++ b/explore/explore.go
@@ -35,7 +35,7 @@ type mockAPIGatewayContext struct {
 
 type mockAPIGatewayRequest struct {
 	Method      string                `json:"method"`
-	Data        interface{}           `json:"data"`
+	Data        interface{}           `json:"body"`
 	Headers     map[string]string     `json:"headers"`
 	QueryParams map[string]string     `json:"queryParams"`
 	PathParams  map[string]string     `json:"pathParams"`


### PR DESCRIPTION
## Problem
`explore.NewAPIGatewayRequest` seems to create a JSON event that doesn't match `sparta.APIGatewayLambdaJSONEvent`

## Solution
Change JSON `data` key to `body`

Still unsure if this is a bug since I'm new to the sparta framework. Changing the actual struct might have a larger impact for those who worked around this issue. Happy to update accordingly for that change if it's felt necessary.