### PR TITLE
Fix Provision heading

### DIFF
--- a/content/docs/s3site/index.md
+++ b/content/docs/s3site/index.md
@@ -71,7 +71,7 @@ typically points to a directory, which will be:
   1. Posted to S3 alongside the Lambda code archive and CloudFormation Templates
   1. Dynamically unpacked by a CloudFormation CustomResource during `provision` to a new S3 bucket.
 
-# <a href="{{< relref "#provision" >}}">Provision</a>
+# Provision
 
 Putting it all together, our `main()` function looks like:
 


### PR DESCRIPTION
## Problem

Unnecessary tags in s3sites docs resulting in:

<img width="789" alt="screen shot 2017-01-17 at 8 22 38 pm" src="https://cloud.githubusercontent.com/assets/10160872/22050909/c83ea3ce-dcf3-11e6-9e44-3ad878e30a7d.png">

## Solution

Remove the tags

## Result

📝 Cleaner docs! 😄 