### PR TITLE
Fix PROTOCOL_ERROR on aws-go-sdk/apigateway/GetRestApi 

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,6 @@
 {
 	"ImportPath": "github.com/mweagle/Sparta",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v74",
 	"Packages": [
 		"./..."
 	],
@@ -18,198 +17,198 @@
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/awserr",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/client",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/credentials",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/defaults",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/request",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/session",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/private/waiter",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/apigateway",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/ecr",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/iam",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/lambda",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/s3",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/s3/s3iface",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/s3/s3manager",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/ses",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/sns",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/aws/aws-sdk-go/service/sts",
-			"Comment": "v1.6.2-1-g6545347",
-			"Rev": "654534755951d5af0bef2b612cf98fe529acdb7b"
+			"Comment": "v1.6.15-1-gb84b5a4",
+			"Rev": "b84b5a456f5f281454e9fbe89b38e34d617f4a51"
 		},
 		{
 			"ImportPath": "github.com/crewjam/go-cloudformation",


### PR DESCRIPTION
Got an error on `go run main.go provision`

Error message: 
```
...
INFO[0022] Checking current APIGateway stage status      APIName=[REDACT]-staging StageName=staging
INFO[0022] DEBUG: Request apigateway/GetRestApis Details:
---[ REQUEST POST-SIGN ]-----------------------------
GET http://apigateway.ap-southeast-1.amazonaws.com/restapis?limit=500 HTTP/1.1
Host: apigateway.ap-southeast-1.amazonaws.com
User-Agent: aws-sdk-go/1.6.2 (go1.7.4; darwin; amd64)
Accept: application/json
Authorization: AWS4-HMAC-SHA256 Credential=[REDACT]/20170122/ap-southeast-1/apigateway/aws4_request, SignedHeaders=accept;host;x-amz-date, Signature=[REDACT]
X-Amz-Date: 20170122T080920Z
Accept-Encoding: gzip


-----------------------------------------------------
DEBU[0022] AWS Request                                   Method=GET Operation=GetRestApis Path="/restapis" Payload={
  Limit: 500
} Service=apigateway
INFO[0023] DEBUG: Response apigateway/GetRestApis Details:
---[ RESPONSE ]--------------------------------------
HTTP/0.0 000 status code 0
Content-Length: 0


-----------------------------------------------------
INFO[0023] DEBUG: Send Request apigateway/GetRestApis failed, will retry, error RequestError: send request failed
caused by: Get https://apigateway.ap-southeast-1.amazonaws.com/restapis?limit=500: stream error: stream ID 1; PROTOCOL_ERROR
...
```

Which has also mentioned on https://github.com/aws/aws-sdk-go/issues/1022.
Welcome for any comments :)