### PR TITLE
Fixed broken link to AWS documentation

### DIFF
--- a/docs/concepts/index.html
+++ b/docs/concepts/index.html
@@ -1826,7 +1826,7 @@ sparta.Main(stackName,
 
 <h2 id="lambda-function">Lambda Function</h2>
 
-<p>A Sparta-compatible lambda is a standard <a href="https://docs.aws.amazon.com/lambda/latest/dg/go-programming-model-handler-types.html/">AWS Lambda Go</a> function. The following function signatures are supported:</p>
+<p>A Sparta-compatible lambda is a standard <a href="https://docs.aws.amazon.com/lambda/latest/dg/go-programming-model-handler-types.html">AWS Lambda Go</a> function. The following function signatures are supported:</p>
 
 <ul>
 <li><code>func ()</code></li>

--- a/docs_source/content/concepts/_index.md
+++ b/docs_source/content/concepts/_index.md
@@ -27,7 +27,7 @@ sparta.Main(stackName,
 
 ## Lambda Function
 
-A Sparta-compatible lambda is a standard [AWS Lambda Go](https://docs.aws.amazon.com/lambda/latest/dg/go-programming-model-handler-types.html/) function. The following function signatures are supported:
+A Sparta-compatible lambda is a standard [AWS Lambda Go](https://docs.aws.amazon.com/lambda/latest/dg/go-programming-model-handler-types.html) function. The following function signatures are supported:
 
 * `func ()`
 * `func () error`


### PR DESCRIPTION
Tested on Chrome, Firefox and IE