### PR TITLE
Handle dot in the username

### DIFF
--- a/aws/cloudformation/util.go
+++ b/aws/cloudformation/util.go
@@ -1049,6 +1049,7 @@ func UserAccountScopedStackName(basename string,
 		return "", awsNameErr
 	}
 	userName := strings.Replace(awsName, " ", "-", -1)
+	userName = strings.Replace(userName, ".", "-", -1)
 	return fmt.Sprintf("%s-%s", basename, userName), nil
 }
 


### PR DESCRIPTION
If you have dots in your username, for instance `sasan.rose`, stack name generated by `UserAccountScopedStackName` will result in validation errors:

```
ValidationError: 1 validation error detected: Value 'MyHelloWorldStack-sasan.rose' at 'stackName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*|arn:[-a-zA-Z0-9:/._+]*
```