### PR TITLE
Avoid creating default state machine role when an external role is set

### DIFF
--- a/aws/step/step.go
+++ b/aws/step/step.go
@@ -919,7 +919,7 @@ func (sm *StateMachine) StateMachineNamedDecorator(stepFunctionResourceName stri
 			},
 		}
 		var iamRoleResourceName string
-		if len(lambdaFunctionResourceNames) != 0 {
+		if len(lambdaFunctionResourceNames) != 0 && sm.roleArn == nil {
 			statesIAMRole := &gocf.IAMRole{
 				AssumeRolePolicyDocument: AssumePolicyDocument,
 			}


### PR DESCRIPTION
When a lambda step is present in the state machine and an external role is supplied via `StateMachine.WithRoleArn()`, the role used by the StateMachine is the default one instead of the one supplied. 

This change avoids creating and using the default role in cases when the role is supplied explicitly.